### PR TITLE
Fixed the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CPSwarm Communication Library
-[![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/cpswarm/deployment-tool.svg)](https://github.com/cpswarm/swarmio/tags)
-[![Build Status](https://travis-ci.com/cpswarm/deployment-tool.svg?branch=master)](https://travis-ci.com/cpswarm/swarmio)  
+[![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/cpswarm/swarmio)](https://github.com/cpswarm/swarmio/tags)
+
 The CPSwarm Communication Library provides a unified interface that tools and swarm members can use to interact with each other.
 ## Getting started
 For more information, see the [WIKI](https://github.com/cpswarm/swarmio/wiki).


### PR DESCRIPTION
I removed the Travis badge because there is no configured Travis CI for swarmio. I also fixed the Git tag badge which was pointing to another repo. 

The badges are from https://shields.io/